### PR TITLE
replace `context` with `this`

### DIFF
--- a/dev/main.js
+++ b/dev/main.js
@@ -80,7 +80,7 @@ Dispatcher.prototype = {
         this.callbacks.push({
         		storeName: name,
             store: store,
-            func: createWrapper(context, callback),
+            func: createWrapper(this, callback),
             deps: [],
             waitFor: createWaitForMethod(store, this)
         });


### PR DESCRIPTION
The `createWrapper` function accepts a `context` and at line 83 seems to be asking for a `context` of `this`.  Was getting errors trying to use this file otherwise.
